### PR TITLE
docs: add CLAUDE.md, API reference, and improve documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,61 @@
+# dot-skills
+
+Personal Claude Code plugin marketplace. The main plugin is `kanban-skill`, a file-based kanban board with a Bun-powered web server for tracking work items across Claude Code sessions.
+
+## Architecture
+
+- **Plugin root:** `plugins/kanban-skill/` -- contains commands, skills, hooks, and server
+- **Server:** Bun + TypeScript (`plugins/kanban-skill/server/`). Entry point is `index.ts`, API routes in `api.ts`
+- **Frontend:** Vanilla HTML/JS/CSS in `server/static/`. Views: Board, Table, Swimlane (workstream-grouped)
+- **Data layer:** Markdown files with YAML frontmatter stored in `kanban/` directories. No database
+
+## Kanban Conventions
+
+### Columns (directories)
+
+- `kanban/todo/` -- not started
+- `kanban/in-progress/` -- actively being worked on
+- `kanban/ready-to-review/` -- complete, awaiting human review
+- `kanban/done/` -- finished
+
+### Ticket files
+
+- Filename format: `<type>--<slug>.md` (double-dash separator)
+- Type prefixes: `feat`, `test`, `bug`, `refactor`, `infra`, `docs`, `spike`
+- Examples: `feat--login.md`, `bug--crash.md`, `refactor--extract-module.md`
+- Move files between directories to change status; never delete
+
+### Workstreams
+
+- Defined in `kanban/workstreams/*.md`
+- Group related tickets with internal ordering
+- Ticket order in the `tickets` list defines recommended execution order
+
+### Blocking
+
+A ticket is blocked if any of these are true:
+- A `depends-on` ticket is not in `ready-to-review/` or `done/`
+- A `depends-on-workstreams` workstream is not completed
+- An earlier ticket in the same workstream's `tickets` list is not done
+
+### Review files
+
+- Required in `kanban/reviews/` for every ticket moved to `ready-to-review/`
+- Same filename as the ticket (e.g., `feat--login.md` in both directories)
+
+## Development
+
+- **Runtime:** Bun (required)
+- **Start server:** `cd plugins/kanban-skill/server && KANBAN_ROOT=$PWD/../../.. bun run index.ts`
+- **Run tests:** `cd plugins/kanban-skill/server && bun test`
+- **No build step required**
+- Server listens on port 3333 by default (configurable via `PORT` env var)
+
+## Important Files
+
+- `plugins/kanban-skill/server/api.ts` -- API routes and business logic
+- `plugins/kanban-skill/server/git.ts` -- Git auto-commit helper
+- `plugins/kanban-skill/server/index.ts` -- Server entry point
+- `plugins/kanban-skill/server/static/` -- Frontend (HTML, CSS, JS modules)
+- `plugins/kanban-skill/skills/kanban-tracker/SKILL.md` -- Board conventions and ticket format
+- `plugins/kanban-skill/skills/ticket-picker/SKILL.md` -- Ticket selection algorithm

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # dot-skills
 
-Personal Claude Code plugin marketplace.
+A personal Claude Code plugin marketplace. Currently ships the **kanban-skill** plugin for file-based kanban board management.
 
 ## Installation
 
@@ -21,15 +21,48 @@ Register this marketplace by adding to `~/.claude/plugins/known_marketplaces.jso
 
 Then enable plugins in Claude Code settings.
 
-## Plugins
+## kanban-skill
 
-### kanban-skill
+Kanban board management with a web viewer for tracking work across Claude Code sessions. Tickets are plain markdown files with YAML frontmatter, organized into directories by status.
 
-Kanban board management with web viewer for tracking work across Claude Code sessions.
+### Features
 
-**Commands:**
-- `/kanban-serve` - Start web viewer at localhost:3333
+- **File-based kanban board** -- markdown tickets with YAML frontmatter, moved between directories to change status
+- **Web viewer with 3 views** -- Board (columns), Table (sortable list), and Swimlane (grouped by workstream)
+- **Workstream grouping** -- logical ticket groupings with progress tracking and recommended execution order
+- **Blocking dependency visualization** -- three dependency types: ticket-to-ticket, workstream, and workstream ordering
+- **Real-time updates** -- Server-Sent Events push board changes to all connected browsers
+- **Markdown editor** -- in-browser ticket editing with live preview
+- **Git auto-commit** -- ticket creates and updates are automatically committed
+- **New ticket creation** -- form-based ticket creation with workstream assignment
 
-**Skills:**
-- `kanban-tracker` - Board management conventions
-- `ticket-picker` - Select next ticket to work on
+### Quick Start
+
+- `/kanban-serve` -- start the web viewer at `localhost:3333` (requires [Bun](https://bun.sh))
+- `/ticket-picker` -- select the next ticket to work on based on priority, dependencies, and workstream order
+- The `kanban-tracker` skill provides board conventions to Claude automatically
+
+### Plugin Components
+
+| Component | Name | Description |
+|-----------|------|-------------|
+| Command | `serve` | Start the web viewer at `localhost:3333` |
+| Skill | `kanban-tracker` | Board structure, ticket format, and workflow conventions |
+| Skill | `ticket-picker` | Ticket selection algorithm based on priority and blocking state |
+| Hook (Stop) | `check-review-files` | Enforce review file creation when tickets move to ready-to-review |
+| Hook (SessionEnd) | `stop-server-on-exit` | Kill the web viewer server when the Claude session ends |
+| Server | Bun + TypeScript | API and SSE endpoint at `localhost:3333` |
+
+### Board Structure
+
+```
+kanban/
+├── workstreams/       # Workstream definitions (grouping + ordering)
+├── todo/              # Not yet started
+├── in-progress/       # Being worked on
+├── ready-to-review/   # Complete, awaiting human review
+├── done/              # Completed and reviewed
+└── reviews/           # Human-readable review/verification guides
+```
+
+Tickets are named `<type>--<slug>.md` (e.g. `feat--add-sse-updates.md`). Supported types: `feature`, `test`, `bug`, `refactor`, `infra`, `docs`, `spike`.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -1,0 +1,143 @@
+# Kanban Skill API Reference
+
+Base URL: `http://localhost:<port>` (port configured in `serve.md`)
+
+## Endpoints
+
+### GET /api/tickets
+
+Returns all tickets grouped by kanban column. Pass `?includeDone=true` to include the done column.
+
+**Response:** `{ "todo": [TicketMeta], "in-progress": [TicketMeta], "ready-to-review": [TicketMeta], "done?": [TicketMeta] }`
+
+**TicketMeta:**
+
+| Field       | Type       | Description                               |
+|-------------|------------|-------------------------------------------|
+| `filename`  | string     | e.g. `feat--my-ticket.md`                 |
+| `title`     | string     | Extracted from first `# Heading` in file  |
+| `type`      | string     | From frontmatter (`feature`, `bug`, etc.) |
+| `priority`  | string     | `high`, `medium`, or `low`                |
+| `created`   | string     | ISO date from frontmatter                 |
+| `workstream`| string?    | Workstream slug, if assigned              |
+| `blockedBy` | string[]?  | Array of blocker slugs, if any            |
+
+---
+
+### GET /api/workstreams
+
+Returns all workstreams with computed progress and status.
+
+**Response:** `{ "workstreams": [WorkstreamMeta] }`
+
+**WorkstreamMeta:**
+
+| Field      | Type                                   | Description                  |
+|------------|----------------------------------------|------------------------------|
+| `slug`     | string                                 | Workstream identifier        |
+| `name`     | string                                 | Title from `# Heading`       |
+| `priority` | string                                 | `high`, `medium`, or `low`   |
+| `status`   | string                                 | Derived (see below)          |
+| `progress` | `{ completed: number, total: number }` | Ticket completion counts     |
+| `tickets`  | string[]                               | Ordered list of ticket slugs |
+
+**Status derivation:** `"completed"` if all tickets are done (and total > 0), otherwise falls back to the frontmatter `status` field (default `"active"`). Sorted by priority (high first), then alphabetically.
+
+---
+
+### GET /api/ticket/:column/:filename
+
+Returns the full markdown content of a single ticket.
+
+- **`:column`** -- `todo`, `in-progress`, `ready-to-review`, or `done`
+- **`:filename`** -- e.g. `feat--my-ticket.md`
+
+**200:** `{ "content": "<full markdown>" }` | **404:** `{ "error": "Not found" }`
+
+---
+
+### PUT /api/ticket/:column/:filename
+
+Updates a ticket's content and auto-commits to git.
+
+**Request body:** `{ "content": "<full markdown>" }`
+
+**Response:** `{ "success": true, "gitCommitted": boolean, "gitError?": string }`
+
+---
+
+### POST /api/tickets
+
+Creates a new ticket in `kanban/todo/`. Filename is derived as `<typePrefix>--<slugified-title>.md` where `typePrefix` is `feat` for type `feature`, otherwise the type value itself.
+
+**Option 1 -- raw markdown:**
+
+```json
+{ "content": "---\ntype: feature\n...\n---\n\n# My Ticket\n..." }
+```
+
+**Option 2 -- structured body:**
+
+```json
+{
+  "type": "feature",
+  "title": "My Ticket",
+  "priority": "high",
+  "description": "Details here",
+  "acceptance_criteria": ["Criterion 1", "Criterion 2"]
+}
+```
+
+Generates full markdown with frontmatter, description, and acceptance criteria sections.
+
+**Response:** `{ "filename": string, "gitCommitted": boolean, "gitError?": string }`
+
+---
+
+### GET /api/events
+
+Server-Sent Events stream for real-time kanban updates.
+
+- Sends `data: connected\n\n` immediately on connection.
+- Sends `data: refresh\n\n` whenever any file under `kanban/` changes (100ms debounce).
+- Headers: `Content-Type: text/event-stream`, `Cache-Control: no-cache`, `Connection: keep-alive`.
+
+---
+
+## Blocking Logic
+
+A ticket's `blockedBy` array is computed from three sources:
+
+1. **`depends-on`** -- Frontmatter lists ticket slugs. If the ticket is NOT in `ready-to-review/` or `done/`, it is a blocker.
+2. **`depends-on-workstreams`** -- Frontmatter lists workstream slugs. If the workstream's completed count does not equal its total, it is a blocker.
+3. **Workstream predecessor ordering** -- If the ticket belongs to a workstream, every preceding ticket in the workstream's `tickets` array must be complete. Incomplete predecessors are added as blockers.
+
+A ticket is considered "complete" if its `.md` file exists in either `kanban/ready-to-review/` or `kanban/done/`.
+
+---
+
+## Example curl Commands
+
+List all tickets:
+```bash
+curl http://localhost:3333/api/tickets
+```
+
+Read a specific ticket:
+```bash
+curl http://localhost:3333/api/ticket/todo/feat--my-ticket.md
+```
+
+Create a ticket:
+```bash
+curl -X POST http://localhost:3333/api/tickets \
+  -H "Content-Type: application/json" \
+  -d '{"type":"bug","title":"Fix login timeout","priority":"high","description":"Login times out after 5s"}'
+```
+
+Update a ticket:
+```bash
+curl -X PUT http://localhost:3333/api/ticket/in-progress/feat--my-ticket.md \
+  -H "Content-Type: application/json" \
+  -d '{"content":"---\ntype: feature\npriority: high\n---\n\n# My Ticket\n\nUpdated content."}'
+```

--- a/kanban/README.md
+++ b/kanban/README.md
@@ -1,25 +1,80 @@
 # Kanban Board
 
-This directory tracks work items for the dot-skills project using the kanban-skill plugin.
+Data store for the project kanban board. Tickets are markdown files with YAML
+frontmatter that move between column directories as work progresses. Managed by
+the `kanban-skill` plugin.
 
-## Structure
+## Directory Structure
 
 ```
 kanban/
-├── README.md          # This file
-├── workstreams/       # Workstream definitions
-├── todo/              # Work not yet started
-├── in-progress/       # Actively being worked on
-├── ready-to-review/   # Complete, awaiting review
-├── done/              # Completed and reviewed
-└── reviews/           # Review/verification guides
+├── workstreams/     # Workstream definitions (*.md)
+├── todo/            # Tickets not yet started
+├── in-progress/     # Tickets being worked on
+├── ready-to-review/ # Complete, awaiting review
+├── done/            # Reviewed and completed
+└── reviews/         # Review guides for completed tickets
 ```
+
+## Ticket Format
+
+Each ticket is a markdown file named `<type>--<kebab-slug>.md`. Structured
+metadata lives in YAML frontmatter; the body is prose and acceptance criteria.
+
+```markdown
+---
+type: feature
+priority: high
+created: 2026-01-15
+workstream: my-workstream
+depends-on: [feat--other-ticket]
+---
+# Ticket Title
+
+## Description
+...
+```
+
+Type prefixes: `feat`, `test`, `bug`, `refactor`, `infra`, `docs`, `spike`.
+
+## Workstream Format
+
+Workstreams group related tickets. Defined in `kanban/workstreams/<slug>.md`:
+
+```markdown
+---
+slug: workstream-ui
+status: active
+priority: high
+created: 2026-02-04
+tickets:
+  - feat--workstreams-api-endpoint
+  - feat--card-workstream-badge
+depends-on-workstreams: []
+tags: [kanban, ui]
+---
+# Workstream UI
+
+## Goal
+<what this workstream achieves when complete>
+```
+
+Ticket order in the `tickets` list is the recommended execution order.
 
 ## Quick Commands
 
-- `/serve` - Start the web UI at localhost:3333
-- `/ticket-picker` - Pick up the next ticket to work on
+- `/kanban-serve` -- start web viewer at localhost:3333
+- `/ticket-picker` -- select next ticket to work on
 
-## Current Workstreams
+## Blocking Rules
 
-- **workstream-ui** - Full workstream support for kanban board web viewer
+1. **Ticket dependency** -- a ticket is blocked when any slug in its
+   `depends-on` list is not yet in `ready-to-review/` or `done/`.
+
+2. **Workstream dependency** -- a ticket is blocked when any workstream in its
+   `depends-on-workstreams` list still has incomplete tickets.
+
+3. **Workstream order** -- a ticket is blocked when an earlier ticket in the
+   same workstream's `tickets` list is not yet in `ready-to-review/` or `done/`.
+
+See `plugins/kanban-skill/skills/kanban-tracker/SKILL.md` for full conventions.

--- a/plugins/kanban-skill/commands/serve.md
+++ b/plugins/kanban-skill/commands/serve.md
@@ -20,16 +20,14 @@ Start the kanban board web viewer at localhost:3333.
 
 4. Tell the user:
    - The board is running at http://localhost:3333
-   - To stop: `kill $(cat .kanban-server.pid) && rm .kanban-server.pid`
    - The server will auto-stop when the Claude session ends
+   - If the server doesn't stop automatically: `pkill -f kanban-skill/server`
 
 ## Example Commands
 
 ```bash
 # Start server in background
 cd "${CLAUDE_PLUGIN_ROOT}/server" && KANBAN_ROOT="${CLAUDE_PROJECT_DIR}" bun run index.ts &
-echo $! > .kanban-server.pid
-echo "Started server with pid $(cat .kanban-server.pid)"
 
 # Open browser (macOS)
 open http://localhost:3333


### PR DESCRIPTION
## Summary

- **CLAUDE.md** — New project-level context file for AI assistants covering architecture, conventions, and development workflow
- **docs/api-reference.md** — New comprehensive API reference documenting all 6 endpoints, request/response schemas, blocking logic, and curl examples
- **README.md** — Rewritten with feature overview, quick start guide, and plugin component table
- **kanban/README.md** — Expanded with ticket and workstream format examples, blocking rules, and column definitions
- **plugins/kanban-skill/commands/serve.md** — Updated stop mechanism to reflect current pkill-based fallback (removed stale PID file references)

## Test plan

- [ ] Verify all markdown renders correctly on GitHub
- [ ] Confirm API reference port numbers match default (3333)
- [ ] Check internal links and file path references are accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)